### PR TITLE
📅 Update 2025 year-end values

### DIFF
--- a/1846058/index.html
+++ b/1846058/index.html
@@ -48,9 +48,10 @@
         <p>None</p>
       <h4>Par</h4>
         <p>$0</p>
-      <!-- <h4 id="getNumOutstanding" asset-code="1846058ORD">Shares Outstanding</h4>-->
+      <h4 id="getNumOutstanding" asset-code="1846058ORD">Shares Outstanding</h4>
         <ul>
           <li> Dec 31, 2024 - 1,500 outstanding</li>
+          <li> Dec 31, 2025 - 1,500 outstanding</li>
         </ul> 
       <h4>Ticker</h4>
         <p>$---<span class="small-symbol">&dagger;</span></p>

--- a/1846058/index.html
+++ b/1846058/index.html
@@ -54,7 +54,7 @@
           <li> Dec 31, 2025 - 1,500 outstanding</li>
         </ul> 
       <h4>Ticker</h4>
-        <p>$---<span class="small-symbol">&dagger;</span></p>
+        <p>$TAD<span class="small-symbol">&dagger;</span></p>
     </section>
     <div id="securitiesDisclaimer" style="margin-top: 35px; text-indent: 0;">
       <div id="tickerDisclaimer"></div>

--- a/1984803/index.html
+++ b/1984803/index.html
@@ -1,7 +1,7 @@
 ﻿<!DOCTYPE html>
 <html>
 <head>
-  <title>Laylor Corporation - Issuers.info</title>
+  <title>Laylor Corporation (Archived) - Issuers.info</title>
   <meta name="viewport" content="width=device-width">
   <link rel="stylesheet" type="text/css" href="../style.css">
 </head>
@@ -10,6 +10,9 @@
   <a href="https://www.laylorcorporation.com?utm_source=blocktransfer&utm_medium=referral&utm_campaign=issuers.info">
     <img class="issuer-logo" src="logo.png" alt="Laylor Corporation Logo" style="width: 50vw">
   </a>
+  <div class="notice">
+    <strong>Notice:</strong> This issuer is no longer a seviced by any TAD3 transfer agents. The materials on this page may be historical, representing client information know at the end of an agreement. BlockTrans Syndicate terminated arrangements with the issuer on 31 Jan 2026 without a known replacement.
+  </div>
   <h2>Laylor Corporation</h2>
     <!-- <h4>Previously Such and Such Co. (CA)</h4> -->
     <section>
@@ -51,7 +54,7 @@
         <p>None</p>
       <h4>Par</h4>
         <p>$0.01</p>
-      <h4 id="getNumOutstanding" asset-code="1984803ORD">Shares Outstanding</h4>
+      <h4>Shares Outstanding</h4>
         <ul>
           <li> Dec 31, 2023 - 79,900,000 outstanding</li>
           <li> Dec 31, 2024 - 80,900,000 outstanding</li>
@@ -125,17 +128,18 @@
       <section>
         <p class="noindent">The Issuer's investor relations team is avaliable at:</p>
           <ul>
-            <li>1318 North Main Street #1170, Summerville, SC 29483</a></li>
+            <li>1318 North Main Street #1170, Summerville, SC 29483</li>
             <li><p class="noindent"><a href="mailto:relations@laylorcorporation.com?subject=Question%20Regarding%20Business%20Activities" style="word-break: break-all;">relations@laylorcorporation.com</a></p></li>
             <li><p class="noindent"><a href="tel:+16504657193">(650) 465-7193</a></p></li>
           </ul>
       </section>
     <h3>Regarding Your Investor Account</h3>
       <section>
-        <p class="noindent">Contact BlockTrans Syndicate, the Issuer's transfer agent:</p>
+        <p class="noindent">For current transfer agent / account questions, contact the Issuer:</p>
           <ul>
-            <li><p class="noindent">99 Wall St #4640, New York, NY 10005</a></p></li>
-            <li><p class="noindent"><a href="mailto:support@blocktransfer.com?subject=Question%20Regarding%20My%20Investor%20Account%20-%20Laylor%20Corporation%20(CIK#1984803)" style="word-break: break-all;">support@blocktransfer.com</a></p></li>
+            <li>1318 North Main Street #1170, Summerville, SC 29483</li>
+            <li><p class="noindent"><a href="mailto:relations@laylorcorporation.com?subject=Question%20Regarding%20My%20Investor%20Account" style="word-break: break-all;">relations@laylorcorporation.com</a></p></li>
+            <li><p class="noindent"><a href="tel:+16504657193">(650) 465-7193</a></p></li>
           </ul>
       </section>
   </section>

--- a/1984803/index.html
+++ b/1984803/index.html
@@ -56,8 +56,9 @@
         <p>$0.01</p>
       <h4>Shares Outstanding</h4>
         <ul>
-          <li> Dec 31, 2023 - 79,900,000 outstanding</li>
-          <li> Dec 31, 2024 - 80,900,000 outstanding</li>
+          <li> Dec 31, 2023 - 80,000,000 outstanding</li>
+          <li> Dec 31, 2024 - 81,000,000 outstanding</li>
+          <li> Dec 31, 2025 - 81,000,000 outstanding</li>
         </ul>
       <h4>Ticker</h4>
         <p>$LAYLOR<span class="small-symbol">&dagger;</span></p>

--- a/1984803/index.html
+++ b/1984803/index.html
@@ -54,7 +54,7 @@
         <p>None</p>
       <h4>Par</h4>
         <p>$0.01</p>
-      <h4>Shares Outstanding</h4>
+      <h4>81,000,000 Final Shares Outstanding</h4>
         <ul>
           <li> Dec 31, 2023 - 80,000,000 outstanding</li>
           <li> Dec 31, 2024 - 81,000,000 outstanding</li>
@@ -64,29 +64,11 @@
         <p>$LAYLOR<span class="small-symbol">&dagger;</span></p>
     </section>
     <div id="securitiesDisclaimer" style="margin-top: 35px; text-indent: 0;">
-      <div id="tickerDisclaimer"></div>
-      <div id="dateDisclaimer"></div>
-    </div>
-    <script>
-      document.getElementById("tickerDisclaimer").innerHTML = `
+      <p style="margin-top: -5px; text-indent: 0;">
         <span class="small-symbol">&dagger;</span>
         <span class="small-text">Designated only by Block Transfer per Issuer preference.</span>
-      `;
-      const now = new Date()
-        .toLocaleDateString("en-US", {
-          day: "numeric",
-          month: "long",
-          year: "numeric",
-          hour: "2-digit",
-          minute: "2-digit"
-      });
-      document.getElementById("dateDisclaimer").innerHTML = `
-        <p style="margin-top: -5px; text-indent: 0;">
-          <span class="small-symbol">*</span>
-          <span class="small-text">As of ${now}.</span>
-        </p>
-      `;
-    </script>
+      </p>
+    </div>
   </section>  
   <h2>Insiders</h2>
     <section>

--- a/1984803/index.html
+++ b/1984803/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width">
   <link rel="stylesheet" type="text/css" href="../style.css">
 </head>
-<body>
+<body data-tad-status="archived">
 <div class="main">
   <a href="https://www.laylorcorporation.com?utm_source=blocktransfer&utm_medium=referral&utm_campaign=issuers.info">
     <img class="issuer-logo" src="logo.png" alt="Laylor Corporation Logo" style="width: 50vw">

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 <a href="https://www.blocktransfer.com"><img alt="Block Transfer" src="https://blocktransfer.com/logo.png" width="558" /></a>
 <br/></div>
 
-# Issuer Materials - <a href="https://issuers.info">Issuers.info
+# Issuer Materials - [Issuers.info](https://issuers.info)
 
 This repository is managed by Block Transfer and provides a secure and organized way to publicly host disclosure documents, such as financial statements, posted by our transfer agent clients.
 

--- a/index.html
+++ b/index.html
@@ -9,9 +9,6 @@
 <img src="logo.png" alt="Issuers.info Logo" class="issuer-logo" style="max-width: 250px;">
 <div class="main" style="max-width: 400px; font-size: 18pt;">
   <ul>
-    <li><a href="1984803">Laylor Corporation</a></li>
-  </ul>
-  <ul>
     <li><a href="1846058">BlockTrans Syndicate</a></li>
   </ul>
   <br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br><br>

--- a/style.css
+++ b/style.css
@@ -40,3 +40,12 @@ section {
   font-weight: bold;
   margin-top: 25pt;
 }
+.notice {
+  border: 8px solid #e26848;
+  background: #144f9b;
+  padding: 21px 21px;
+  border-radius: 18px;
+  margin: 21px 0;
+  text-indent: 0;
+  color: #ffff;
+}


### PR DESCRIPTION
This repo's branding was last amended in November of 2023, so there's a lot of work going ahead to deprecate the centralized control and integrate into the DUNA alongside visual upgrades like [pending prototypes](https://github.com/NYTEMODEONLY/gmedash) ([Discussion](https://discordapp.com/channels/1102309240145707049/1102309240741310503/1462642474626580611)). Notwithstanding, I just need to update the year's close-out shares outstanding for c(2)-11. And I'll start the process of visually deprecated prior clients given the [donation prep](https://github.com/JFWooten4/agenda/issues/18#issuecomment-3597738925) ([Tracking](https://github.com/blocktransfer/SEC-publications/blob/main/examinations/response-8/action-items.md#small)).

